### PR TITLE
cpu compatibility if model loaded from model zoo

### DIFF
--- a/batch_face/face_detection/alignment.py
+++ b/batch_face/face_detection/alignment.py
@@ -442,7 +442,10 @@ def remove_prefix(state_dict, prefix):
 def load_model(model, pretrained_path, load_to_cpu, network: str):
     if pretrained_path is None:
         url = pretrained_urls[network]
-        pretrained_dict = torch.utils.model_zoo.load_url(url)
+        if load_to_cpu:
+            pretrained_dict = torch.utils.model_zoo.load_url(url, map_location=lambda storage, loc: storage)
+        else:
+            pretrained_dict = torch.utils.model_zoo.load_url(url, map_location=lambda storage, loc: storage.cuda(device))
     else:
         if load_to_cpu:
             pretrained_dict = torch.load(


### PR DESCRIPTION
Hi,
great work!
found a little bug, when you don't load a local pre trained Model but instead load the Model via Model zoo from URL the load_to_cpu Argument isn't checked and so it throws an error, when run on a cpu only machine (or cuda visible devices = -1)
this little code shoud fix it.