### PR TITLE
Update Typing

### DIFF
--- a/batch_face/face_parsing/farl.py
+++ b/batch_face/face_parsing/farl.py
@@ -1,5 +1,8 @@
 import torch
-from typing import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 import numpy as np
 import cv2
 


### PR DESCRIPTION
Python changed the way typing extensions are imported in 3.8 ^ . I applied a simple fix to make it compatible with versions below 3.8 (see this post for details: https://stackoverflow.com/questions/61206437/importerror-cannot-import-name-literal-from-typing)