### PR TITLE
Fix a bug when input is already torch tensor and does not need any further modifications

### DIFF
--- a/batch_face/face_detection/alignment.py
+++ b/batch_face/face_detection/alignment.py
@@ -815,6 +815,8 @@ def batch_detect(net, images, device, is_tensor=False, threshold=0.5, cv=False,
         except ValueError:
             raise NotImplementedError("Input images must of same size")
         img = torch.from_numpy(img)
+    else:
+        img = images
     
     if resize == 1 and max_size != -1:
         # compute resize factor


### PR DESCRIPTION
I found this bug while trying to use the package to run Retinaface in batches. The changes I applied fix the issue and I've been using them in my code for months.
I am raising this PR to get the main codebase fixed too. I am looking forward to your code review!